### PR TITLE
Fix for preventing I/O on closed file

### DIFF
--- a/agents/model.py
+++ b/agents/model.py
@@ -453,6 +453,7 @@ class Model:
         self._close_func = func
 
     def close(self):
+        self.model.pause()
         if self._close_func:
             self._close_func(self)
 

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -352,7 +352,6 @@ class MainWindow(QtWidgets.QMainWindow):
         super().__init__()
 
     def closeEvent(self, event):
-        self.model.pause()
         self.model.close()
         super().closeEvent(event)
 

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -352,6 +352,7 @@ class MainWindow(QtWidgets.QMainWindow):
         super().__init__()
 
     def closeEvent(self, event):
+        self.model.pause()
         self.model.close()
         super().closeEvent(event)
 


### PR DESCRIPTION
If you are writing to a file in your `step` function with `f.write()`, and close the file with `f.close()` using `Model.on_close`, there is a high chance of getting an `I/O operation on closed file` error, since the timer that calls toggled buttons does not immediately terminate.

This fixes it by adding a call to `Model.pause()` just before the model closes.