### PR TITLE
"Quickstart" option 

### DIFF
--- a/agents/model.py
+++ b/agents/model.py
@@ -12,9 +12,6 @@ class AgentShape(Enum):
 
 class Agent:
     def __init__(self):
-        # Associated simulation area.
-        self.__model = None
-
         # Destroyed agents are not drawn and are removed from their area.
         self.__destroyed = False
 
@@ -38,6 +35,9 @@ class Agent:
         self.__current_tile = None
         self.selected = False
         self.shape = AgentShape.ARROW
+
+        # Associated simulation area.
+        get_quickstart_model().add_agent(self)
 
     # Should be overwritten by a subclass
     def setup(self, model):
@@ -504,3 +504,9 @@ class SimpleModel(Model):
 
         self.add_button("Setup", setup_wrapper)
         self.add_toggle_button("Go", step_wrapper)
+
+def get_quickstart_model():
+    global quickstart_model
+    if not 'quickstart_model' in globals():
+        quickstart_model = Model("AgentsPy model", 50, 50)
+    return quickstart_model

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -14,6 +14,7 @@ from PyQt5.QtCore import QPointF
 from PyQt5.QtGui import QPainter, QPainterPath, QColor, QPolygonF
 
 from agents.model import (
+    get_quickstart_model,
     AgentShape,
     ButtonSpec,
     ToggleSpec,
@@ -534,3 +535,6 @@ def run(model):
 
     # Application was closed, clean up and exit
     sys.exit(0)
+
+def quick_run():
+    run(get_quickstart_model())

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,8 @@
+from agents import *
+
+a = Agent()
+a.jump_to(100,100)
+a.direction = 0
+a.forward(100)
+
+quick_run()


### PR DESCRIPTION
Agents now belong to a default "`quickstart_model`", meaning that simple simulations can be done without creating a model explicitly. This should make it more similar to the `turtle` library from python.