### PR TITLE
Making simulations without model objects

### DIFF
--- a/agents/model.py
+++ b/agents/model.py
@@ -576,11 +576,11 @@ class Model:
     @property
     def agents(self):
         self.remove_destroyed_agents()
-        return iter(self.__agents)
+        return self.__agents
 
     @agents.setter
     def agents(self, agents):
-        self.__agents = list(agents)
+        self.__agents = agents
 
     def __setitem__(self, key, item):
         self.variables[key] = item
@@ -591,6 +591,117 @@ class Model:
     def __delitem__(self, key):
         del self.variables[key]
 
+__model = Model("AgentsPy model")
+
+def add_agent(agent, setup=True):
+    __model.add_agent(agent, setup)
+
+def add_agents(agents):
+    __model.add_agents(agents)
+
+def tile(x, y):
+    return __model.tile(x, y)
+
+def reset():
+    __model.reset()
+
+def reload():
+    __model.reload()
+
+def update_plots():
+    __model.update_plots()
+
+def remove_destroyed_agents():
+    __model.remove_destroyed_agents()
+
+def clear_plots():
+    __model.clear_plots()
+
+def add_controller_row():
+    __model.controller_row()
+
+def button(func, label=None):
+    if not label:
+        label=func.__name__
+    __model.add_button(label, func)
+
+def toggle_button(func, label=None):
+    if not label:
+        label=func.__name__
+    __model.add_toggle_button(label, func)
+
+def slider(variable, initial, minval=0, maxval=100):
+    __model.add_slider(variable, minval, maxval, initial)
+
+def add_checkbox(variable):
+    __model.add_checkbox(variable)
+
+def line_chart(variable, color):
+    __model.line_chart(variable, color)
+
+def multi_line_chart(variables, colors):
+    __model.multi_line_chart(variables, colors)
+
+def bar_chart(variables, color):
+    __model.bar_chart(variables, color)
+
+def histogram(variable, minimum, maximum, bins, color):
+    __model.histogram(variable, minimum, maximum, bins, color)
+
+def monitor(variable):
+    __model.monitor(variable)
+
+def add_ellipse(x,y,w,h,color):
+    return __model.add_ellipse(x,y,w,h,color)
+
+def add_rect(x,y,w,h):
+    return __model.add_rect(x,y,w,h)
+
+def get_shapes():
+    return __model.get_shapes()
+
+def clear_shapes():
+    __model.clear_shapes()
+
+def is_paused():
+    return __model.is_paused()
+
+def pause():
+    __model.pause()
+
+def unpause():
+    __model.unpause()
+
+def on_close(func):
+    __model.on_close(func)
+
+def close():
+    __model.close()
+
+def enable_wrapping():
+    __model.enable_wrapping()
+
+def disable_wrapping():
+    __model.disable_wrapping()
+
+def wrapping():
+    return __model.wrapping()
+
+def get_var(variable):
+    return __model[variable]
+
+def set_var(variable, value):
+    __model[variable] = value
+
+def size(w,h):
+    __model.x_tiles = w
+    __model.y_tiles = h
+
+def title(name):
+    __model.title = name
+
+def agents():
+    return __model.agents
 
 class SimpleModel(Model):
     def __init__(self, title,
@@ -613,6 +724,8 @@ class SimpleModel(Model):
         self.add_button("Setup", setup_wrapper)
         self.add_toggle_button("Go", step_wrapper)
 
+def get_anonymous_model():
+    return __model
 
 def get_quickstart_model():
     global quickstart_model

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -13,21 +13,7 @@ from PyQt5.QtChart import (
 from PyQt5.QtCore import QPointF
 from PyQt5.QtGui import QPainter, QPainterPath, QColor, QPolygonF
 
-from agents.model import (
-    get_quickstart_model,
-    AgentShape,
-    ButtonSpec,
-    ToggleSpec,
-    SliderSpec,
-    CheckboxSpec,
-    LineChartSpec,
-    MultiLineChartSpec,
-    BarChartSpec,
-    HistogramSpec,
-    MonitorSpec,
-    EllipseStruct,
-    RectStruct,
-)
+from agents.model import *
 
 
 class SimulationArea(QtWidgets.QWidget):
@@ -502,7 +488,7 @@ class Application:
                     isinstance(controller, ToggleButton)
                     and controller.isChecked()
                 ):
-                    controller.func(controller.model)
+                    controller.func()
                 elif isinstance(controller, Monitor):
                     controller.update_label()
 
@@ -514,7 +500,7 @@ class Application:
 
     def add_button(self, button_spec, row):
         btn = QtWidgets.QPushButton(button_spec.label)
-        btn.clicked.connect(lambda x: button_spec.function(self.model))
+        btn.clicked.connect(lambda x: button_spec.function())
         row.addWidget(btn)
         self.controllers.append(btn)
 
@@ -609,15 +595,18 @@ class Application:
             elif type(plot_spec) is HistogramSpec:
                 self.add_histogram(plot_spec, plots_box)
 
-
-def run(model):
+def run(setup, step):
+    global __model
     # Initialize application
     qapp = QtWidgets.QApplication(sys.argv)
 
+    button(setup, "Setup")
+    button(step, "Step")
+    toggle_button(step, "Go")
     # We need to store a reference to the application, even though we are not
     # using it, as otherwise it will be garbage-collected and the UI will get
     # some very weird behavior.
-    app = Application(model)  # noqa: F841
+    app = Application(get_anonymous_model())  # noqa: F841
 
     # Launch the application
     qapp.exec_()

--- a/examples/no_model.py
+++ b/examples/no_model.py
@@ -1,0 +1,12 @@
+from agents import *
+
+def setup():
+    size(50, 50)
+    title("My model")
+    add_agent(Agent())
+
+def step():
+    a = agents()[0]
+    a.forward()
+
+run(setup, step) # this always sets up Setup, Step, Go buttons


### PR DESCRIPTION
An example of how the library might look if instantiating a model was not required, but all `Model` class fields and methods instead referred to the same global object.

To avoid breaking too much functionality around the library, it works by creating a global object `__model`, and then creating equivalent global functions for each `Model` method, which refer to that specific global object. It's not very pretty, but I think this is the best  way to do it while making the least changes to the existing library.